### PR TITLE
specified ip at ngrok tunnel initialisation

### DIFF
--- a/ncfs.example.sh
+++ b/ncfs.example.sh
@@ -97,7 +97,7 @@ ngrok config add-authtoken $NGROK_AUTH_TOKEN
 # Run NGROK on background
 echo "🚀 NGROK: Starting NGROK on background..."
 
-ngrok tcp $NGROK_TCP_PORT > /dev/null &
+ngrok tcp 127.0.0.1:$NGROK_TCP_PORT > /dev/null &
 
 # Wait for NGROK to start
 echo "🕑 NGROK: Waiting for NGROK to start..."


### PR DESCRIPTION
Hi Baris,

I wanted to set up a tunnel using the shell script you mentioned. However, I faced some difficulties connecting to the server using the URL provided by ngrok. To fix this issue, I made some changes to the script by adding my local IP and "127.0.0.1." Surprisingly, these adjustments worked, and now the tunnel is functioning correctly.

I want to assure you that these modifications don't affect the tunnel initialization process, and they should work with more configurations